### PR TITLE
refactor: Buttonコンポーネントの見た目を修正する 

### DIFF
--- a/frontend/src/components/button.tsx
+++ b/frontend/src/components/button.tsx
@@ -22,9 +22,7 @@ export function Button({ label, onClick }: Button) {
         className={`
           ${pixelFont.className}
           relative z-10
-          h-16
-          px-16
-          rounded-xl
+          p-8
           text-white
           text-xl
           tracking-[0.25em]
@@ -38,8 +36,7 @@ export function Button({ label, onClick }: Button) {
       >
         {label.toUpperCase()}
       </ShadcnButton>
-      <div className="absolute -bottom-2 left-0 right-0 h-4 bg-[#0a5aa0] rounded-b-xl" />
-      <div className="absolute -bottom-1 left-4 right-4 h-1 bg-white rounded-full opacity-90 pointer-events-none" />
+      <div className="absolute -bottom-1 left-0 right-0 h-4 bg-white rounded-b" />
     </div>
   );
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -6,7 +6,7 @@
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
-  --radius: 0.625rem;
+  --radius: 0.4rem;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
- [x] セルフレビューをしたらチェックを入れてください
- [x] AI reviewを依頼し、解決した

## 関連 issue
resolve #67 
<!-- resolve #<issue-number> -->

## やったこと

### 概要
ボタンの見た目をピクセル風に合わせるため、サイズや丸みを微調整した。
<!-- 変更内容を 1 行程度でまとめまとめてください。 (チケットタイトルと被っても OK) -->

### 詳細
- px-16を削除し、p-8に修正
- h-8を削除
- roundedを調整し、丸みを減らす。
<!-- 変更内容をリスト形式でまとめてください。 -->


### 影響範囲

<!-- DB や API エンドポイントの変更など、大きな影響がある場合はその旨をここに書いてください。 -->


### 動作確認方法
変更前
<img width="777" height="398" alt="スクリーンショット 2025-11-28 16 44 38" src="https://github.com/user-attachments/assets/0ed89d21-d806-4623-bba5-2d0eee4644b3" />

変更後
<img width="791" height="442" alt="スクリーンショット 2025-11-28 16 43 57" src="https://github.com/user-attachments/assets/6aa88f7b-03c5-4fa3-b687-a9c1210093fe" />

<!-- 動作確認方法と確認内容をリスト形式でまとめてください。 -->


<!-- もし、フロントエンドに修正をしていた場合はスクリーンショットを貼ること -->

## 備考

<!-- この PR についての課題や、議論したいことがあればここに書いてください。 -->


<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->
