### PR TITLE
feat: dockerize backend and add scanner service with Bluetooth support

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     libpq-dev \
     postgresql-client \
+    bluez \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   db:
     image: postgres:15
+    container_name: cpj-db
     environment:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=password
@@ -22,6 +23,24 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+
+  scanner:
+    build: .
+    container_name: cpj-scanner
+    # scanner runs in host mode to access bluetooth, so it cannot resolve 'db' hostname.
+    # It must connect to localhost:5432 (since db exposes port 5432 to host).
+    network_mode: "host"
+    privileged: true
+    environment:
+      - DATABASE_URL=postgresql://user:password@localhost:5432/mydb
+    depends_on:
+      - db
+    volumes:
+      - .:/app
+      - /var/run/dbus:/var/run/dbus
+      # /dev is often needed for direct hardware access
+      - /dev:/dev
+    command: python rfid_scanner.py
 
 volumes:
   postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ uvicorn==0.24.0
 sqlalchemy==2.0.23
 psycopg2-binary==2.9.9
 alembic==1.12.1
+pyserial
+pexpect

--- a/backend/utility/rfid_connect.py
+++ b/backend/utility/rfid_connect.py
@@ -73,10 +73,10 @@ def bind_rfcomm(port, mac_address):
     """MACアドレスを仮想シリアルポートにバインドする"""
     print(f"{mac_address} を {port} にバインドします...")
     try:
-        subprocess.run(['sudo', 'rfcomm', 'release', port], check=False)
+        subprocess.run(['rfcomm', 'release', port], check=False)
         time.sleep(1)
 
-        subprocess.run(['sudo', 'rfcomm', 'bind', port, mac_address, '1'], check=True)
+        subprocess.run(['rfcomm', 'bind', port, mac_address, '1'], check=True)
         print("バインドに成功しました。")
         time.sleep(2) # デバイスファイルが安定するのを待つ
         return True


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
- [x] セルフレビューをしたらチェックを入れてください
- [ ] AI reviewを依頼し、解決した

## 関連 issue
#41 
<!-- resolve #<issue-number> -->

## やったこと
- バックエンドをすべてdocker上で動作するようにした。

### 概要
- バックエンドでの動作をdocker上ですべて動作するようにした。
<!-- 変更内容を 1 行程度でまとめまとめてください。 (チケットタイトルと被っても OK) -->

### 詳細
- 従来、バックエンドのうちdbとfastAPI部分に関してはdocker上で管理できていたが、rfidのscanがまだdocker化されていなかった
- すべてdocker上で管理できるようにして、`docker compose up`でdbとfastAPIが起動した上でscannerが稼働するようにしたので、`docker compose up`だけでバックエンド系サービスはすべて稼働する
<!-- 変更内容をリスト形式でまとめてください。 -->


### 影響範囲
バックエンド側
<!-- DB や API エンドポイントの変更など、大きな影響がある場合はその旨をここに書いてください。 -->


### 動作確認方法
cd backend
docker compose up
<!-- 動作確認方法と確認内容をリスト形式でまとめてください。 -->


<!-- もし、フロントエンドに修正をしていた場合はスクリーンショットを貼ること -->

## 備考

<!-- この PR についての課題や、議論したいことがあればここに書いてください。 -->


<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->
